### PR TITLE
exmarscube 오류 수정

### DIFF
--- a/exMarsCube/main/src/hw/exMarsCube/ExMarsCubeDefine.ts
+++ b/exMarsCube/main/src/hw/exMarsCube/ExMarsCubeDefine.ts
@@ -1,117 +1,116 @@
-export type Packet = Array<number>
-export enum Color {
-  off = 'O',
-  red = 'R',
-  green = 'G',
-  blue = 'B',
-  yellow = 'Y',
-  purple = 'P',
-  white = 'W',
-  skip = 'S',
+export const Color = {
+  off: 'O',
+  red: 'R',
+  green: 'G',
+  blue: 'B',
+  yellow: 'Y',
+  purple: 'P',
+  white: 'W',
+  skip: 'S'
 }
-export enum Index {
-  menu = 0,
-  face = 7,
-  faceDirection = 7,
-  recordRequest = 8,
-  recordResponse = 9,
-  centerColor = 9,
-  cellColor = 11,
-  posDirTor = 12,
-  sensingRequest = 28,
-  sensingResponse = 28,
+export const Index = {
+  menu: 0,
+  face: 7,
+  faceDirection: 7,
+  recordRequest: 8,
+  recordResponse: 9,
+  centerColor: 9,
+  cellColor: 11,
+  posDirTor: 12,
+  sensingRequest: 28,
+  sensingResponse: 28
 }
-export enum Action {
-  faceMove = 1,
-  faceResetAll,
-  faceMoveWithMotor,
+export const Action = {
+  faceMove: 1,
+  faceResetAll: 2,
+  faceMoveWithMotor: 3
 }
-export enum Rotation {
-  zero,
-  thirty,
-  sixty,
-  ninety,
-  aHundredTwenty,
-  aHundredFifty,
-  aHundredEighty,
+export const Rotation = {
+  zero: 0,
+  thirty: 1,
+  sixty: 2,
+  ninety: 3,
+  aHundredTwenty: 4,
+  aHundredFifty: 5,
+  aHundredEighty: 6
 }
-export enum FaceColor {
-  white,
-  yellow,
-  green,
-  blue,
-  red,
-  purple,
-  all = 7,
+export const FaceColor = {
+  white: 0,
+  yellow: 1,
+  green: 2,
+  blue: 3,
+  red: 4,
+  purple: 5,
+  all: 7
 }
-export enum CellColor {
-  off,
-  red,
-  green,
-  blue,
-  yellow,
-  purple = 6,
-  white,
-  skip,
+export const CellColor = {
+  off: 0,
+  red: 1,
+  green: 2,
+  blue: 3,
+  yellow: 4,
+  purple: 6,
+  white: 7,
+  skip: 8
 }
-export enum DirectionState {
-  brake,
-  cw,
-  ccw,
-  passive,
+export const DirectionState = {
+  brake: 0,
+  cw: 1,
+  ccw: 2,
+  passive: 3
 }
-export enum DirectionFromFace {
-  forwardCW,
-  forwardCCW,
-  rightCW,
-  rightCCW,
-  leftCW,
-  leftCCW,
-  upCW,
-  upCCW,
-  downCW,
-  donwCCW,
-  backwardCW,
-  backwardCCW,
+export const DirectionFromFace = {
+  forwardCW: 0,
+  forwardCCW: 1,
+  rightCW: 2,
+  rightCCW: 3,
+  leftCW: 4,
+  leftCCW: 5,
+  upCW: 6,
+  upCCW: 7,
+  downCW: 8,
+  donwCCW: 9,
+  backwardCW: 10,
+  backwardCCW: 11
 }
-export enum Pitch {
-  C,
-  CSharp,
-  D,
-  DSharp,
-  E,
-  F,
-  FSharp,
-  G,
-  GSharp,
-  A,
-  ASharp,
-  B,
-  Rest,
+export const Pitch = {
+  C: 0,
+  CSharp: 1,
+  D: 2,
+  DSharp: 3,
+  E: 4,
+  F: 5,
+  FSharp: 6,
+  G: 7,
+  GSharp: 8,
+  A: 9,
+  ASharp: 10,
+  B: 11,
+  Rest: 12
 }
-export enum Switch {
-  Off,
-  On,
+export const Switch = {
+  Off: 0,
+  On: 1
 }
-export enum Mode {
-  main,
-  sub,
+export const Mode = {
+  main: 0,
+  sub: 1
 }
-export enum Record {
-  normal,
-  fifthRelay,
-  halfBlind,
-  fullBlind,
-  timePenalty,
-  twenty_twentyEightMode,
-  minimumRotation,
-  zeroTwoMode,
+export const Record = {
+  normal: 0,
+  fifthRelay: 1,
+  halfBlind: 2,
+  fullBlind: 3,
+  timePenalty: 4,
+  twenty_twentyEightMode: 5,
+  minimumRotation: 6,
+  zeroTwoMode: 7
 }
-export enum PacketType {
-  sendByte = 7,
-  received = 7,
+export const PacketType = {
+  sendByte: 7,
+  received: 7
 }
-export enum PacketDelimiter {
-  header = 0,
-  terminator = 90,
+export const PacketDelimiter = {
+  header: 0,
+  terminator: 90
 }

--- a/exMarsCube/main/src/hw/exMarsCube/ExMarsCubePacket.ts
+++ b/exMarsCube/main/src/hw/exMarsCube/ExMarsCubePacket.ts
@@ -3,17 +3,16 @@ import {
   FaceColor,
   Index,
   Mode,
-  Packet,
   PacketDelimiter,
   PacketType,
 } from './ExMarsCubeDefine'
 
 export class ExMarsCubePacket {
-  faceCell: Array<Packet> = new Array(6)
-  faceRotDir: Packet = new Array(6)
-  record: Array<Packet> = new Array(8)
-  currentMode: Packet = new Array(2)  
-  readonly sendPacketType: number = PacketType.sendByte
+  faceCell = new Array(6)
+  faceRotDir = new Array(6)
+  record = new Array(8)
+  currentMode = new Array(2)  
+  readonly sendPacketType = PacketType.sendByte
 
   txPacket = (
     index: number,
@@ -21,8 +20,8 @@ export class ExMarsCubePacket {
     param2: number,
     param3: number,
     param4: number,
-  ): Packet => {
-    const buffer: Packet = new Array<number>(this.sendPacketType)
+  ): Array<number> => {
+    const buffer = new Array<number>(this.sendPacketType)
 
     buffer[0] = PacketDelimiter.header
     buffer[1] = index
@@ -35,16 +34,16 @@ export class ExMarsCubePacket {
     return buffer
   }
 
-  txPacketMenuSetting = (main: number, sub: number): Packet => {
+  txPacketMenuSetting = (main: number, sub: number): Array<number> => {
     return this.txPacket(Index.menu, 11, main, sub, 255)
   }
 
-  txPacketModeSetting = (index: number, mode: number): Packet => {
+  txPacketModeSetting = (index: number, mode: number): Array<number> => {
     return this.txPacket(Index.menu, 30, index, mode, 255)
   }
 
-  txPacketSetCenterColor = (face: number, color: number): Packet => {
-    const index: number = (face << 5) | Index.centerColor
+  txPacketSetCenterColor = (face: number, color: number): Array<number> => {
+    const index = (face << 5) | Index.centerColor
     return this.txPacket(index, color, 0, 0, 0)
   }
 
@@ -58,12 +57,12 @@ export class ExMarsCubePacket {
     color6: number,
     color7: number,
     color8: number,
-  ): Packet => {
-    const index: number = (face << 5) | Index.cellColor
-    const para1: number = (color1 << 4) | color2
-    const para2: number = (color3 << 4) | color4
-    const para3: number = (color5 << 4) | color6
-    const para4: number = (color7 << 4) | color8
+  ): Array<number> => {
+    const index = (face << 5) | Index.cellColor
+    const para1 = (color1 << 4) | color2
+    const para2 = (color3 << 4) | color4
+    const para3 = (color5 << 4) | color6
+    const para4 = (color7 << 4) | color8
 
     return this.txPacket(index, para1, para2, para3, para4)
   }
@@ -73,8 +72,8 @@ export class ExMarsCubePacket {
     position: number,
     direction: number,
     torque: number,
-  ): Packet => {
-    const index: number = (face << 5) | Index.posDirTor
+  ): Array<number> => {
+    const index = (face << 5) | Index.posDirTor
     let pos = 0
 
     if (position < 2) {
@@ -88,11 +87,11 @@ export class ExMarsCubePacket {
     return this.txPacket(index, pos, direction, torque, 0)
   }
 
-  txPacketMoveFace = (face: number, rotation: number): Packet => {
+  txPacketMoveFace = (face: number, rotation: number): Array<number> => {
     let para = 0
-    let buffer: Packet = new Array<number>(this.sendPacketType)
+    let buffer = new Array<number>(this.sendPacketType)
 
-    if (0 <= rotation && rotation <= 15) {
+    if (rotation >= 0 && rotation <= 15) {
       if (face === FaceColor.white || face === FaceColor.green || face === FaceColor.red) {
         para = (rotation << 4) & 240
       } else if (
@@ -115,15 +114,15 @@ export class ExMarsCubePacket {
     return buffer
   }
 
-  txPacketResetAllFace = (): Packet => {
+  txPacketResetAllFace = (): Array<number> => {
     return this.txPacket(Index.face, Action.faceResetAll, 0, 0, 0)
   }
 
-  txPacketFaceMoveWithMotor = (face: number, rotation: number): Packet => {
+  txPacketFaceMoveWithMotor = (face: number, rotation: number): Array<number> => {
     let para = 0
-    let buffer: Packet = new Array<number>(this.sendPacketType)
+    let buffer = new Array<number>(this.sendPacketType)
 
-    if (0 <= rotation && rotation <= 15) {
+    if (rotation >= 0  && rotation <= 15) {
       if (face === FaceColor.white || face === FaceColor.green || face === FaceColor.red) {
         para = (rotation << 4) & 240
       } else if (
@@ -151,7 +150,7 @@ export class ExMarsCubePacket {
     rotation1: number,
     face2: number,
     rotation2: number,
-  ): Packet => {
+  ): Array<number> => {
     let para2 = 0
     let para3 = 0
     let para4 = 0
@@ -200,31 +199,31 @@ export class ExMarsCubePacket {
     return this.txPacket(Index.face, Action.faceMoveWithMotor, para2, para3, para4)
   }
 
-  txPacketDiceStart = (dice: number): Packet => {
-    const index: number = Index.menu
+  txPacketDiceStart = (dice: number): Array<number> => {
+    const index = Index.menu
     return this.txPacket(index, 21, dice, 255, 255)
   }
 
-  txPacketRecord = (recordIndex: number): Packet => {
-    const index: number = (7 << 5) | Index.recordRequest
+  txPacketRecord = (recordIndex: number): Array<number> => {
+    const index = (7 << 5) | Index.recordRequest
     return this.txPacket(index, recordIndex, 255, 255, 255)
   }
 
-  txPacketSensingRequest = (): Packet => {
-    const index: number = (FaceColor.all << 5) | Index.sensingRequest
+  txPacketSensingRequest = (): Array<number> => {
+    const index = (FaceColor.all << 5) | Index.sensingRequest
     return this.txPacket(index, 255, 255, 255, 255)
   }
 
-  rxParser = async(packet: Packet): Promise<void> => {
-    const index: number = packet[1] & 31
+  rxParser = async(packet: Array<number>): Promise<void> => {
+    const index = packet[1] & 31
 
     if (index === Index.menu) {
       this.currentMode[Mode.main] = packet[3]
       this.currentMode[Mode.sub] = packet[4]
     } else if (index === Index.sensingResponse) {
-      const face: number = (packet[1] >> 5) & 15
+      const face = (packet[1] >> 5) & 15
 
-      if (0 <= face && face <= 5) {
+      if (face <= 0 && face <= 5) {
         if (face === FaceColor.white) {
           this.faceCell[face][0] = (packet[3] >> 4) & 15
           this.faceCell[face][1] = packet[3] & 15
@@ -346,7 +345,7 @@ export class ExMarsCubePacket {
       }
     } else if (index === Index.recordResponse) {
       // 0: 최신, 1: 차순 ... , 5: 최고
-      const recordIndex: number = (packet[1] >> 5) & 15
+      const recordIndex = (packet[1] >> 5) & 15
       this.record[recordIndex][packet[2]] = (packet[3] << 16) | (packet[4] << 8) | packet[5]
     }
   }
@@ -356,7 +355,7 @@ export class ExMarsCubePacket {
   }
 
   convertEnumType = (fromObj: any, toObj: any, value: any): any => {
-    const key: string | undefined = Object.keys(fromObj).find((key) => fromObj[key] === value)
+    const key = Object.keys(fromObj).find((key) => fromObj[key] === value)
     return key ? toObj[key] : 'undefind'
   }
 }

--- a/exMarsCube/main/src/hw/exMarsCube/FIFO.ts
+++ b/exMarsCube/main/src/hw/exMarsCube/FIFO.ts
@@ -1,22 +1,18 @@
-import { Packet } from './ExMarsCubeDefine'
-
 export class FIFO {
-  private items: Array<Packet> = [[]]
+  private items = [[]]
   public length = 0
 
-  constructor() {}
-
-  enqueue = async(item: Packet): Promise<void> => {
+  enqueue = async(item: Array<number>): Promise<void> => {
     this.items.push(item)
     this.length = this.items.length
   }
 
-  peek = (): Packet => {
+  peek = (): Array<number> => {
     return this.items[0]
   }
 
-  dequeue = async(): Promise<Packet> => {
-    const buffer: Packet | undefined = this.items.shift()
+  dequeue = async(): Promise<Array<number>> => {
+    const buffer = this.items.shift()
     this.length = this.items.length
     return buffer ? buffer : []
   }


### PR DESCRIPTION
- ExMarsCubeDefine.ts
- ExmarsCubePacket.ts
- FIFO.ts
- CommandRunner.ts
의 오류를 수정하여 PR를 보내드립니다.
https://aicodiny.com/simul/playground 에서 테스트 결과 이상없이 동작하였습니다.
아래는 '_export.sh' 실행 결과입니다. 실행결과 'exmarscube/main/out' 폴더 하위에 이상 없이 빌드되었습니다.

$ sh _export.sh
Scope: all 4 workspace projects
.                                        |   +2 +
Done in 1s

> codiny-hw-marty@ build C:\Users\Computer\desktop\exmarscube_codiny_iframe\exmarscube
> turbo run build


Update available v1.10.16 ≫ v1.11.2
Changelog: https://github.com/vercel/turbo/releases/tag/v1.11.2
Run "npx @turbo/codemod update" to update

Follow @turborepo for updates: https://x.com/turborepo
• Packages in scope: eslint-config-custom, tsconfig, web
• Running build in 3 packages
• Remote caching disabled
web:build: cache miss, executing 2a109507bc97b9ac
web:build:
web:build: > web@1.0.0 build C:\Users\Computer\Desktop\exMarscube_Codiny_iframe\exMarsCube\main
web:build: > next build
web:build:
web:build:    Creating an optimized production build ...
web:build:  ✓ Compiled successfully
web:build:    Linting and checking validity of types ...
web:build:    Collecting page data ...
web:build:    Generating static pages (0/4) ...
   Generating static pages (1/4)
   Generating static pages (2/4)
   Generating static pages (3/4)
 ✓ Generating static pages (4/4)
web:build:    Finalizing page optimization ...
web:build:    Collecting build traces ...
web:build:
web:build: Route (app)                              Size     First Load JS
web:build: ┌ ○ /                                    20.8 kB         118 kB
web:build: └ ○ /_not-found                          882 B          81.4 kB
web:build: + First Load JS shared by all            80.5 kB
web:build:   ├ chunks/22a4498a-2cb186ed1547c301.js  50.9 kB
web:build:   ├ chunks/925-86424306858e0e06.js       27.6 kB
web:build:   ├ chunks/main-app-807886f7d2904c08.js  229 B
web:build:   └ chunks/webpack-aa742d003426164c.js   1.73 kB
web:build:
web:build:
web:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
web:build:

 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total
  Time:    25.212s
