### PR TITLE
ensuring side arg is string in turn block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _export-upload.sh
 node_modules
 _tmp
 
+steps-for-making-changes.md

--- a/marty/main/src/hw/marty/MartyBlocks.ts
+++ b/marty/main/src/hw/marty/MartyBlocks.ts
@@ -155,6 +155,7 @@ export class MartyBlocks {
    * @param side - 0 = left or 1 = right
    */
   turn = async (steps: string, side: string): Promise<void> => {
+    side = ensureString(side);
     const moveTime = 1500
     let stepsInt = parseInt(steps)
     if (stepsInt === 0 || stepsInt < 0 || stepsInt > 20) {
@@ -468,4 +469,23 @@ export class MartyBlocks {
     const lightSensor = martyConnector.getLightSensorReading(channel)
     return lightSensor || 0
   }
+}
+
+/**
+ * Makes sure the argument is string 
+ * Also makes sure of wrong argument formats
+ * @param arg - Argument to be checked
+ * @returns The argument as string
+ */
+const ensureString = (arg: any): string => {
+  if (typeof arg === 'string') {
+    return arg
+  }
+  if (typeof arg === 'number') {
+    return arg.toString()
+  }
+  if (typeof arg === 'boolean') {
+    return arg.toString()
+  }
+  return ''
 }


### PR DESCRIPTION
Issue: The 'turn' marty block expects the side argument to be 'string' but it was coming in as a number.

Solution: Ensuring the 'side' argument is 'string'